### PR TITLE
Fix fib translation issue 1 and 2

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n:number) : number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -2,7 +2,7 @@
 
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req : any, res : any) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
fib.ts and fibRoute.ts both had function parameters without defined types. Type definitions were added to resolve the errors.

These changes were tested using fib.test.ts test values as well as random values entered via npm start server.